### PR TITLE
[hot-fix] fix index page button

### DIFF
--- a/pages/index.en-US.mdx
+++ b/pages/index.en-US.mdx
@@ -12,5 +12,5 @@ import TitleHero from "../components/index/titleHero";
   description="Rooch is a Fast, Modular, Secured, Developer-Friendly infrastructure
           solution for building Web3 Native applications"
   button="Learn More"
-  buttonHref="/docs"
+  buttonHref="/docs/introduction"
 />

--- a/pages/index.zh-CN.mdx
+++ b/pages/index.zh-CN.mdx
@@ -11,5 +11,5 @@ import TitleHero from "../components/index/titleHero";
   slogan="加速世界向去中心化的转变"
   description="Rooch 是一个高效，安全，模块化，开发者体验优秀的实现 Web3 原生应用的基础设施解决方案"
   button="了解更多"
-  buttonHref="/docs"
+  buttonHref="/docs/introduction"
 />


### PR DESCRIPTION
The button on the index page routes to `/docs` which is not the correct URL. it should be `/docs/introduction`